### PR TITLE
Import fix for deprecated module name

### DIFF
--- a/python/tk_multi_perforce/__init__.py
+++ b/python/tk_multi_perforce/__init__.py
@@ -9,5 +9,5 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .connection import connect, open_connection
-from .operations import check_out_current_scene, revert_scene_changes, sync_files, open_sync_files_dialog
+from .operations import check_out_current_scene, revert_scene_changes, open_sync_files_dialog
 from .pending_publishes import show_pending_publishes


### PR DESCRIPTION
sync_files became a module to open the UI instead, requiring rename. 